### PR TITLE
Allow up to 4 decimal places in % values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const postcss = require('postcss');
 
 const px = (val) => val ? `${val}px` : '0';
 const pct = (val) => val ? `${val}%` : '0';
-const round = (val) => Number.isInteger(val) ? val : val.toPrecision(4);
+const round = (val) => Number.isInteger(val) ? val : val.toPrecision(6);
 const column = (columns, val) => pct(round((100 / columns) * val));
 
 function flexboxgrid({ columns = 12, gutter = 30 } = {}) {


### PR DESCRIPTION
For certain combinations of widths and gutters the error accumulates to
at least 1px causing the last column to wrap to the next line.

Allowing for 4 decimal places keeps the error under 1px.